### PR TITLE
samples: add quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,25 @@
 1. Try an example:
 
 ```javascript
-// Imports the Google Cloud client library
-const sc = require('@google-cloud/securitycenter');
+async function quickstart(
+  organization = 'YOUR_ORGANIZATION', // Your GCP organization
+) {
+  const sc = require('@google-cloud/security-center');
+
+  // Create a client
+  const client = new sc.SecurityCenterClient();
+
+  const formattedParent = client.organizationPath(organization);
+  const reqSource = {};
+  const request = {
+    parent: formattedParent,
+    source: reqSource,
+  };
+
+  const [source] = await client.createSource(request);
+  // The newly created source.
+  console.log(source);
+}
 ```
 
 
@@ -81,4 +98,3 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=
 [auth]: https://cloud.google.com/docs/authentication/getting-started
-

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ async function quickstart(
 
   const [source] = await client.createSource(request);
   // The newly created source.
+  console.log('Source created.');
   console.log(source);
 }
 ```

--- a/samples/package.json
+++ b/samples/package.json
@@ -10,6 +10,8 @@
     "@google-cloud/security-center": "^0.1.1"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
+    "execa": "^1.0.0",
     "mocha": "^5.2.0"
   }
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -2,6 +2,9 @@
   "name": "nodejs-security-center-samples",
   "main": "quickstart.js",
   "private": true,
+  "engines": {
+    "node": ">=8"
+  },
   "scripts": {
     "test": "mocha system-test"
   },

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -17,7 +17,7 @@
 
 // [START securitycenter_quickstart]
 async function quickstart(
-  organization = 'YOUR_ORGANIZATION', // Your GCP organization
+  organization = 'YOUR_ORGANIZATION' // Your GCP organization
 ) {
   const sc = require('@google-cloud/security-center');
 

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -16,7 +16,26 @@
 'use strict';
 
 // [START securitycenter_quickstart]
-// Imports the Google Cloud client library
-const sc = require('@google-cloud/securitycenter');
-console.log(sc);
+async function quickstart(
+  organization = 'YOUR_ORGANIZATION', // Your GCP organization
+) {
+  const sc = require('@google-cloud/security-center');
+
+  // Create a client
+  const client = new sc.SecurityCenterClient();
+
+  const formattedParent = client.organizationPath(organization);
+  const reqSource = {};
+  const request = {
+    parent: formattedParent,
+    source: reqSource,
+  };
+
+  const [source] = await client.createSource(request);
+  // The newly created source.
+  console.log(source);
+}
 // [END securitycenter_quickstart]
+
+const args = process.argv.slice(2);
+quickstart(...args).catch(console.error);

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -33,6 +33,7 @@ async function quickstart(
 
   const [source] = await client.createSource(request);
   // The newly created source.
+  console.log('Source created.');
   console.log(source);
 }
 // [END securitycenter_quickstart]

--- a/samples/system-test/no-test.js
+++ b/samples/system-test/no-test.js
@@ -1,1 +1,0 @@
-console.log('no tests yet');

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2019, Google, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const {assert} = require('chai');
+const execa = require('execa');
+const uuid = require('uuid');
+const organization = process.env['GCLOUD_ORGANIZATION']
+
+// Skipped because createSource requires special permissions only
+// grantable on the organization level.
+it.skip('should run the quickstart', async () => {
+  const {stdout} = await execa.shell(
+    `node quickstart ${organization}`
+  );
+
+  console.log(stdout);
+});

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -27,5 +27,5 @@ it.skip('should run the quickstart', async () => {
     `node quickstart ${organization}`
   );
 
-  console.log(stdout);
+  assert.match(stdout, /Source created\./);
 });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -17,15 +17,12 @@
 
 const {assert} = require('chai');
 const execa = require('execa');
-const uuid = require('uuid');
-const organization = process.env['GCLOUD_ORGANIZATION']
+const organization = process.env['GCLOUD_ORGANIZATION'];
 
 // Skipped because createSource requires special permissions only
 // grantable on the organization level.
 it.skip('should run the quickstart', async () => {
-  const {stdout} = await execa.shell(
-    `node quickstart ${organization}`
-  );
+  const {stdout} = await execa.shell(`node quickstart ${organization}`);
 
   assert.match(stdout, /Source created\./);
 });


### PR DESCRIPTION
System tests will not run because it requires organization-level
permissions, but it's better than having no quickstart.