### PR TITLE
made punctuation consistent

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,7 +21,7 @@ Examples of unacceptable behavior by participants include:
 * Publishing other's private information,
 such as physical or electronic
 addresses, without explicit permission
-* Other unethical or unprofessional conduct.
+* Other unethical or unprofessional conduct
 
 Project maintainers have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions


### PR DESCRIPTION
I removed a period to make the punctuation consistent with the other items in the list. Also, this change makes the list match the original Contributor Covenant more closely:
http://contributor-covenant.org/version/1/2/0/