### PR TITLE
feat: deferred client initialization

### DIFF
--- a/src/v1/security_center_client.ts
+++ b/src/v1/security_center_client.ts
@@ -45,9 +45,14 @@ export class SecurityCenterClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  securityCenterStub: Promise<{[name: string]: Function}>;
+  securityCenterStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of SecurityCenterClient.
@@ -71,8 +76,6 @@ export class SecurityCenterClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -102,25 +105,28 @@ export class SecurityCenterClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof SecurityCenterClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -136,7 +142,7 @@ export class SecurityCenterClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -144,28 +150,28 @@ export class SecurityCenterClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      assetPathTemplate: new gaxModule.PathTemplate(
+      assetPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/assets/{asset}'
       ),
-      findingPathTemplate: new gaxModule.PathTemplate(
+      findingPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sources/{source}/findings/{finding}'
       ),
-      notificationConfigPathTemplate: new gaxModule.PathTemplate(
+      notificationConfigPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/notificationConfigs/{notification_config}'
       ),
-      organizationPathTemplate: new gaxModule.PathTemplate(
+      organizationPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}'
       ),
-      organizationAssetPathTemplate: new gaxModule.PathTemplate(
+      organizationAssetPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/assets/{asset}/securityMarks'
       ),
-      organizationSettingsPathTemplate: new gaxModule.PathTemplate(
+      organizationSettingsPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/organizationSettings'
       ),
-      organizationSourceFindingPathTemplate: new gaxModule.PathTemplate(
+      organizationSourceFindingPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sources/{source}/findings/{finding}/securityMarks'
       ),
-      sourcePathTemplate: new gaxModule.PathTemplate(
+      sourcePathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sources/{source}'
       ),
     };
@@ -174,32 +180,32 @@ export class SecurityCenterClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      groupAssets: new gaxModule.PageDescriptor(
+      groupAssets: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'groupByResults'
       ),
-      groupFindings: new gaxModule.PageDescriptor(
+      groupFindings: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'groupByResults'
       ),
-      listAssets: new gaxModule.PageDescriptor(
+      listAssets: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'listAssetsResults'
       ),
-      listFindings: new gaxModule.PageDescriptor(
+      listFindings: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'listFindingsResults'
       ),
-      listNotificationConfigs: new gaxModule.PageDescriptor(
+      listNotificationConfigs: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'notificationConfigs'
       ),
-      listSources: new gaxModule.PageDescriptor(
+      listSources: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'sources'
@@ -210,13 +216,15 @@ export class SecurityCenterClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const runAssetDiscoveryResponse = protoFilesRoot.lookup(
@@ -227,7 +235,7 @@ export class SecurityCenterClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      runAssetDiscovery: new gaxModule.LongrunningDescriptor(
+      runAssetDiscovery: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         runAssetDiscoveryResponse.decode.bind(runAssetDiscoveryResponse),
         runAssetDiscoveryMetadata.decode.bind(runAssetDiscoveryMetadata)
@@ -235,7 +243,7 @@ export class SecurityCenterClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.securitycenter.v1.SecurityCenter',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -246,17 +254,35 @@ export class SecurityCenterClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.securityCenterStub) {
+      return this.securityCenterStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.securitycenter.v1.SecurityCenter.
-    this.securityCenterStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.securityCenterStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.securitycenter.v1.SecurityCenter'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.securitycenter.v1.SecurityCenter,
-      opts
+          (this._protos as any).google.cloud.securitycenter.v1.SecurityCenter,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -300,9 +326,9 @@ export class SecurityCenterClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -316,6 +342,8 @@ export class SecurityCenterClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.securityCenterStub;
   }
 
   /**
@@ -450,6 +478,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createSource(request, options, callback);
   }
   createFinding(
@@ -539,6 +568,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createFinding(request, options, callback);
   }
   createNotificationConfig(
@@ -629,6 +659,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createNotificationConfig(
       request,
       options,
@@ -714,6 +745,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteNotificationConfig(
       request,
       options,
@@ -787,6 +819,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.getIamPolicy(request, options, callback);
   }
   getNotificationConfig(
@@ -868,6 +901,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getNotificationConfig(
       request,
       options,
@@ -953,6 +987,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getOrganizationSettings(
       request,
       options,
@@ -1030,6 +1065,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getSource(request, options, callback);
   }
   setFindingState(
@@ -1117,6 +1153,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.setFindingState(request, options, callback);
   }
   setIamPolicy(
@@ -1186,6 +1223,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.setIamPolicy(request, options, callback);
   }
   testIamPermissions(
@@ -1255,6 +1293,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.testIamPermissions(request, options, callback);
   }
   updateFinding(
@@ -1349,6 +1388,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'finding.name': request.finding!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateFinding(request, options, callback);
   }
   updateNotificationConfig(
@@ -1434,6 +1474,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'notification_config.name': request.notificationConfig!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateNotificationConfig(
       request,
       options,
@@ -1522,6 +1563,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'organization_settings.name': request.organizationSettings!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateOrganizationSettings(
       request,
       options,
@@ -1610,6 +1652,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'source.name': request.source!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateSource(request, options, callback);
   }
   updateSecurityMarks(
@@ -1700,6 +1743,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'security_marks.name': request.securityMarks!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateSecurityMarks(request, options, callback);
   }
 
@@ -1793,6 +1837,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.runAssetDiscovery(request, options, callback);
   }
   groupAssets(
@@ -1994,6 +2039,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.groupAssets(request, options, callback);
   }
 
@@ -2150,6 +2196,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.groupAssets.createStream(
       this._innerApiCalls.groupAssets as gax.GaxCall,
       request,
@@ -2348,6 +2395,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.groupFindings(request, options, callback);
   }
 
@@ -2494,6 +2542,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.groupFindings.createStream(
       this._innerApiCalls.groupFindings as gax.GaxCall,
       request,
@@ -2701,6 +2750,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listAssets(request, options, callback);
   }
 
@@ -2860,6 +2910,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listAssets.createStream(
       this._innerApiCalls.listAssets as gax.GaxCall,
       request,
@@ -3062,6 +3113,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listFindings(request, options, callback);
   }
 
@@ -3213,6 +3265,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listFindings.createStream(
       this._innerApiCalls.listFindings as gax.GaxCall,
       request,
@@ -3308,6 +3361,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listNotificationConfigs(
       request,
       options,
@@ -3359,6 +3413,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listNotificationConfigs.createStream(
       this._innerApiCalls.listNotificationConfigs as gax.GaxCall,
       request,
@@ -3454,6 +3509,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listSources(request, options, callback);
   }
 
@@ -3501,6 +3557,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listSources.createStream(
       this._innerApiCalls.listSources as gax.GaxCall,
       request,
@@ -3838,8 +3895,9 @@ export class SecurityCenterClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.securityCenterStub.then(stub => {
+      return this.securityCenterStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v1beta1/security_center_client.ts
+++ b/src/v1beta1/security_center_client.ts
@@ -45,9 +45,14 @@ export class SecurityCenterClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  securityCenterStub: Promise<{[name: string]: Function}>;
+  securityCenterStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of SecurityCenterClient.
@@ -71,8 +76,6 @@ export class SecurityCenterClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -102,25 +105,28 @@ export class SecurityCenterClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof SecurityCenterClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -136,7 +142,7 @@ export class SecurityCenterClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -144,22 +150,22 @@ export class SecurityCenterClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      findingPathTemplate: new gaxModule.PathTemplate(
+      findingPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sources/{source}/findings/{finding}'
       ),
-      organizationPathTemplate: new gaxModule.PathTemplate(
+      organizationPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}'
       ),
-      organizationAssetPathTemplate: new gaxModule.PathTemplate(
+      organizationAssetPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/assets/{asset}/securityMarks'
       ),
-      organizationSettingsPathTemplate: new gaxModule.PathTemplate(
+      organizationSettingsPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/organizationSettings'
       ),
-      organizationSourceFindingPathTemplate: new gaxModule.PathTemplate(
+      organizationSourceFindingPathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sources/{source}/findings/{finding}/securityMarks'
       ),
-      sourcePathTemplate: new gaxModule.PathTemplate(
+      sourcePathTemplate: new this._gaxModule.PathTemplate(
         'organizations/{organization}/sources/{source}'
       ),
     };
@@ -168,27 +174,27 @@ export class SecurityCenterClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      groupAssets: new gaxModule.PageDescriptor(
+      groupAssets: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'groupByResults'
       ),
-      groupFindings: new gaxModule.PageDescriptor(
+      groupFindings: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'groupByResults'
       ),
-      listAssets: new gaxModule.PageDescriptor(
+      listAssets: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'listAssetsResults'
       ),
-      listFindings: new gaxModule.PageDescriptor(
+      listFindings: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'findings'
       ),
-      listSources: new gaxModule.PageDescriptor(
+      listSources: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'sources'
@@ -199,13 +205,15 @@ export class SecurityCenterClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const runAssetDiscoveryResponse = protoFilesRoot.lookup(
@@ -216,7 +224,7 @@ export class SecurityCenterClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      runAssetDiscovery: new gaxModule.LongrunningDescriptor(
+      runAssetDiscovery: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         runAssetDiscoveryResponse.decode.bind(runAssetDiscoveryResponse),
         runAssetDiscoveryMetadata.decode.bind(runAssetDiscoveryMetadata)
@@ -224,7 +232,7 @@ export class SecurityCenterClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.securitycenter.v1beta1.SecurityCenter',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -235,17 +243,36 @@ export class SecurityCenterClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.securityCenterStub) {
+      return this.securityCenterStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.securitycenter.v1beta1.SecurityCenter.
-    this.securityCenterStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.securityCenterStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.securitycenter.v1beta1.SecurityCenter'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.securitycenter.v1beta1.SecurityCenter,
-      opts
+          (this._protos as any).google.cloud.securitycenter.v1beta1
+            .SecurityCenter,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -284,9 +311,9 @@ export class SecurityCenterClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -300,6 +327,8 @@ export class SecurityCenterClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.securityCenterStub;
   }
 
   /**
@@ -434,6 +463,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createSource(request, options, callback);
   }
   createFinding(
@@ -523,6 +553,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createFinding(request, options, callback);
   }
   getIamPolicy(
@@ -592,6 +623,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.getIamPolicy(request, options, callback);
   }
   getOrganizationSettings(
@@ -673,6 +705,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getOrganizationSettings(
       request,
       options,
@@ -758,6 +791,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getSource(request, options, callback);
   }
   setFindingState(
@@ -845,6 +879,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.setFindingState(request, options, callback);
   }
   setIamPolicy(
@@ -914,6 +949,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.setIamPolicy(request, options, callback);
   }
   testIamPermissions(
@@ -983,6 +1019,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.testIamPermissions(request, options, callback);
   }
   updateFinding(
@@ -1072,6 +1109,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'finding.name': request.finding!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateFinding(request, options, callback);
   }
   updateOrganizationSettings(
@@ -1154,6 +1192,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'organization_settings.name': request.organizationSettings!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateOrganizationSettings(
       request,
       options,
@@ -1240,6 +1279,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'source.name': request.source!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateSource(request, options, callback);
   }
   updateSecurityMarks(
@@ -1324,6 +1364,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       'security_marks.name': request.securityMarks!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateSecurityMarks(request, options, callback);
   }
 
@@ -1417,6 +1458,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.runAssetDiscovery(request, options, callback);
   }
   groupAssets(
@@ -1579,6 +1621,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.groupAssets(request, options, callback);
   }
 
@@ -1696,6 +1739,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.groupAssets.createStream(
       this._innerApiCalls.groupAssets as gax.GaxCall,
       request,
@@ -1840,6 +1884,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.groupFindings(request, options, callback);
   }
 
@@ -1932,6 +1977,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.groupFindings.createStream(
       this._innerApiCalls.groupFindings as gax.GaxCall,
       request,
@@ -2097,6 +2143,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listAssets(request, options, callback);
   }
 
@@ -2214,6 +2261,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listAssets.createStream(
       this._innerApiCalls.listAssets as gax.GaxCall,
       request,
@@ -2357,6 +2405,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listFindings(request, options, callback);
   }
 
@@ -2449,6 +2498,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listFindings.createStream(
       this._innerApiCalls.listFindings as gax.GaxCall,
       request,
@@ -2544,6 +2594,7 @@ export class SecurityCenterClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listSources(request, options, callback);
   }
 
@@ -2591,6 +2642,7 @@ export class SecurityCenterClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listSources.createStream(
       this._innerApiCalls.listSources as gax.GaxCall,
       request,
@@ -2850,8 +2902,9 @@ export class SecurityCenterClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.securityCenterStub.then(stub => {
+      return this.securityCenterStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,13 +1,13 @@
 {
-  "updateTime": "2020-03-04T12:40:40.245405Z",
+  "updateTime": "2020-03-05T23:15:57.060814Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "541b1ded4abadcc38e8178680b0677f65594ea6f",
-        "internalRef": "298686266",
-        "log": "541b1ded4abadcc38e8178680b0677f65594ea6f\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 298686266\n\nc0d171acecb4f5b0bfd2c4ca34fc54716574e300\n  Updated to include the Notification v1 API.\n\nPiperOrigin-RevId: 298652775\n\n2346a9186c0bff2c9cc439f2459d558068637e05\nAdd Service Directory v1beta1 protos and configs\n\nPiperOrigin-RevId: 298625638\n\na78ed801b82a5c6d9c5368e24b1412212e541bb7\nPublishing v3 protos and configs.\n\nPiperOrigin-RevId: 298607357\n\n4a180bfff8a21645b3a935c2756e8d6ab18a74e0\nautoml/v1beta1 publish proto updates\n\nPiperOrigin-RevId: 298484782\n\n6de6e938b7df1cd62396563a067334abeedb9676\nchore: use the latest gapic-generator and protoc-java-resource-name-plugin in Bazel workspace.\n\nPiperOrigin-RevId: 298474513\n\n244ab2b83a82076a1fa7be63b7e0671af73f5c02\nAdds service config definition for bigqueryreservation v1\n\nPiperOrigin-RevId: 298455048\n\n"
+        "sha": "f0b581b5bdf803e45201ecdb3688b60e381628a8",
+        "internalRef": "299181282",
+        "log": "f0b581b5bdf803e45201ecdb3688b60e381628a8\nfix: recommendationengine/v1beta1 update some comments\n\nPiperOrigin-RevId: 299181282\n\n10e9a0a833dc85ff8f05b2c67ebe5ac785fe04ff\nbuild: add generated BUILD file for Routes Preferred API\n\nPiperOrigin-RevId: 299164808\n\n86738c956a8238d7c77f729be78b0ed887a6c913\npublish v1p1beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299152383\n\n73d9f2ad4591de45c2e1f352bc99d70cbd2a6d95\npublish v1: update with absolute address in comments\n\nPiperOrigin-RevId: 299147194\n\nd2158f24cb77b0b0ccfe68af784c6a628705e3c6\npublish v1beta2: update with absolute address in comments\n\nPiperOrigin-RevId: 299147086\n\n7fca61292c11b4cd5b352cee1a50bf88819dd63b\npublish v1p2beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146903\n\n583b7321624736e2c490e328f4b1957335779295\npublish v1p3beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146674\n\n638253bf86d1ce1c314108a089b7351440c2f0bf\nfix: add java_multiple_files option for automl text_sentiment.proto\n\nPiperOrigin-RevId: 298971070\n\n373d655703bf914fb8b0b1cc4071d772bac0e0d1\nUpdate Recs AI Beta public bazel file\n\nPiperOrigin-RevId: 298961623\n\ndcc5d00fc8a8d8b56f16194d7c682027b2c66a3b\nfix: add java_multiple_files option for automl classification.proto\n\nPiperOrigin-RevId: 298953301\n\na3f791827266f3496a6a5201d58adc4bb265c2a3\nchore: automl/v1 publish annotations and retry config\n\nPiperOrigin-RevId: 298942178\n\n01c681586d8d6dbd60155289b587aee678530bd9\nMark return_immediately in PullRequest deprecated.\n\nPiperOrigin-RevId: 298893281\n\nc9f5e9c4bfed54bbd09227e990e7bded5f90f31c\nRemove out of date documentation for predicate support on the Storage API\n\nPiperOrigin-RevId: 298883309\n\nfd5b3b8238d783b04692a113ffe07c0363f5de0f\ngenerate webrisk v1 proto\n\nPiperOrigin-RevId: 298847934\n\n"
       }
     },
     {

--- a/test/gapic-security_center-v1.ts
+++ b/test/gapic-security_center-v1.ts
@@ -104,12 +104,30 @@ describe('v1.SecurityCenterClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new securitycenterModule.v1.SecurityCenterClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.securityCenterStub, undefined);
+    await client.initialize();
+    assert(client.securityCenterStub);
+  });
+  it('has close method', () => {
+    const client = new securitycenterModule.v1.SecurityCenterClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('createSource', () => {
     it('invokes createSource without error', done => {
       const client = new securitycenterModule.v1.SecurityCenterClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.ICreateSourceRequest = {};
       request.parent = '';
@@ -133,6 +151,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.ICreateSourceRequest = {};
       request.parent = '';
@@ -158,6 +178,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.ICreateFindingRequest = {};
       request.parent = '';
@@ -181,6 +203,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.ICreateFindingRequest = {};
       request.parent = '';
@@ -206,6 +230,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.ICreateNotificationConfigRequest = {};
       request.parent = '';
@@ -229,6 +255,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.ICreateNotificationConfigRequest = {};
       request.parent = '';
@@ -257,6 +285,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IDeleteNotificationConfigRequest = {};
       request.name = '';
@@ -280,6 +310,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IDeleteNotificationConfigRequest = {};
       request.name = '';
@@ -308,6 +340,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -331,6 +365,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -356,6 +392,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGetNotificationConfigRequest = {};
       request.name = '';
@@ -379,6 +417,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGetNotificationConfigRequest = {};
       request.name = '';
@@ -404,6 +444,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGetOrganizationSettingsRequest = {};
       request.name = '';
@@ -427,6 +469,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGetOrganizationSettingsRequest = {};
       request.name = '';
@@ -455,6 +499,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGetSourceRequest = {};
       request.name = '';
@@ -478,6 +524,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGetSourceRequest = {};
       request.name = '';
@@ -503,6 +551,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.ISetFindingStateRequest = {};
       request.name = '';
@@ -526,6 +576,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.ISetFindingStateRequest = {};
       request.name = '';
@@ -551,6 +603,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -574,6 +628,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -599,6 +655,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -622,6 +680,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -647,6 +707,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateFindingRequest = {};
       request.finding = {};
@@ -671,6 +733,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateFindingRequest = {};
       request.finding = {};
@@ -697,6 +761,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateNotificationConfigRequest = {};
       request.notificationConfig = {};
@@ -721,6 +787,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateNotificationConfigRequest = {};
       request.notificationConfig = {};
@@ -750,6 +818,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateOrganizationSettingsRequest = {};
       request.organizationSettings = {};
@@ -774,6 +844,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateOrganizationSettingsRequest = {};
       request.organizationSettings = {};
@@ -803,6 +875,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateSourceRequest = {};
       request.source = {};
@@ -827,6 +901,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateSourceRequest = {};
       request.source = {};
@@ -853,6 +929,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateSecurityMarksRequest = {};
       request.securityMarks = {};
@@ -877,6 +955,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IUpdateSecurityMarksRequest = {};
       request.securityMarks = {};
@@ -903,6 +983,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IRunAssetDiscoveryRequest = {};
       request.parent = '';
@@ -933,6 +1015,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IRunAssetDiscoveryRequest = {};
       request.parent = '';
@@ -966,6 +1050,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGroupAssetsRequest = {};
       request.parent = '';
@@ -993,6 +1079,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGroupAssetsRequest = {};
       request.parent = '';
@@ -1025,6 +1113,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGroupFindingsRequest = {};
       request.parent = '';
@@ -1052,6 +1142,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IGroupFindingsRequest = {};
       request.parent = '';
@@ -1084,6 +1176,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IListAssetsRequest = {};
       request.parent = '';
@@ -1111,6 +1205,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IListAssetsRequest = {};
       request.parent = '';
@@ -1143,6 +1239,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IListFindingsRequest = {};
       request.parent = '';
@@ -1170,6 +1268,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IListFindingsRequest = {};
       request.parent = '';
@@ -1202,6 +1302,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IListNotificationConfigsRequest = {};
       request.parent = '';
@@ -1232,6 +1334,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IListNotificationConfigsRequest = {};
       request.parent = '';
@@ -1264,6 +1368,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IListSourcesRequest = {};
       request.parent = '';
@@ -1291,6 +1397,8 @@ describe('v1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1.IListSourcesRequest = {};
       request.parent = '';

--- a/test/gapic-security_center-v1beta1.ts
+++ b/test/gapic-security_center-v1beta1.ts
@@ -104,12 +104,30 @@ describe('v1beta1.SecurityCenterClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new securitycenterModule.v1beta1.SecurityCenterClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.securityCenterStub, undefined);
+    await client.initialize();
+    assert(client.securityCenterStub);
+  });
+  it('has close method', () => {
+    const client = new securitycenterModule.v1beta1.SecurityCenterClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('createSource', () => {
     it('invokes createSource without error', done => {
       const client = new securitycenterModule.v1beta1.SecurityCenterClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.ICreateSourceRequest = {};
       request.parent = '';
@@ -133,6 +151,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.ICreateSourceRequest = {};
       request.parent = '';
@@ -158,6 +178,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.ICreateFindingRequest = {};
       request.parent = '';
@@ -181,6 +203,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.ICreateFindingRequest = {};
       request.parent = '';
@@ -206,6 +230,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -229,6 +255,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -254,6 +282,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IGetOrganizationSettingsRequest = {};
       request.name = '';
@@ -277,6 +307,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IGetOrganizationSettingsRequest = {};
       request.name = '';
@@ -305,6 +337,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IGetSourceRequest = {};
       request.name = '';
@@ -328,6 +362,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IGetSourceRequest = {};
       request.name = '';
@@ -353,6 +389,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.ISetFindingStateRequest = {};
       request.name = '';
@@ -376,6 +414,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.ISetFindingStateRequest = {};
       request.name = '';
@@ -401,6 +441,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -424,6 +466,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -449,6 +493,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -472,6 +518,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -497,6 +545,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IUpdateFindingRequest = {};
       request.finding = {};
@@ -521,6 +571,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IUpdateFindingRequest = {};
       request.finding = {};
@@ -547,6 +599,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IUpdateOrganizationSettingsRequest = {};
       request.organizationSettings = {};
@@ -571,6 +625,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IUpdateOrganizationSettingsRequest = {};
       request.organizationSettings = {};
@@ -600,6 +656,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IUpdateSourceRequest = {};
       request.source = {};
@@ -624,6 +682,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IUpdateSourceRequest = {};
       request.source = {};
@@ -650,6 +710,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IUpdateSecurityMarksRequest = {};
       request.securityMarks = {};
@@ -674,6 +736,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IUpdateSecurityMarksRequest = {};
       request.securityMarks = {};
@@ -700,6 +764,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IRunAssetDiscoveryRequest = {};
       request.parent = '';
@@ -730,6 +796,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IRunAssetDiscoveryRequest = {};
       request.parent = '';
@@ -763,6 +831,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IGroupAssetsRequest = {};
       request.parent = '';
@@ -790,6 +860,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IGroupAssetsRequest = {};
       request.parent = '';
@@ -822,6 +894,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IGroupFindingsRequest = {};
       request.parent = '';
@@ -849,6 +923,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IGroupFindingsRequest = {};
       request.parent = '';
@@ -881,6 +957,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IListAssetsRequest = {};
       request.parent = '';
@@ -908,6 +986,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IListAssetsRequest = {};
       request.parent = '';
@@ -940,6 +1020,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IListFindingsRequest = {};
       request.parent = '';
@@ -967,6 +1049,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IListFindingsRequest = {};
       request.parent = '';
@@ -999,6 +1083,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IListSourcesRequest = {};
       request.parent = '';
@@ -1026,6 +1112,8 @@ describe('v1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1beta1.IListSourcesRequest = {};
       request.parent = '';

--- a/test/gapic-security_center-v1p1beta1.ts
+++ b/test/gapic-security_center-v1p1beta1.ts
@@ -104,12 +104,30 @@ describe('v1p1beta1.SecurityCenterClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new securitycenterModule.v1p1beta1.SecurityCenterClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.securityCenterStub, undefined);
+    await client.initialize();
+    assert(client.securityCenterStub);
+  });
+  it('has close method', () => {
+    const client = new securitycenterModule.v1p1beta1.SecurityCenterClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('createSource', () => {
     it('invokes createSource without error', done => {
       const client = new securitycenterModule.v1p1beta1.SecurityCenterClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.ICreateSourceRequest = {};
       request.parent = '';
@@ -133,6 +151,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.ICreateSourceRequest = {};
       request.parent = '';
@@ -158,6 +178,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.ICreateFindingRequest = {};
       request.parent = '';
@@ -181,6 +203,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.ICreateFindingRequest = {};
       request.parent = '';
@@ -206,6 +230,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.ICreateNotificationConfigRequest = {};
       request.parent = '';
@@ -229,6 +255,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.ICreateNotificationConfigRequest = {};
       request.parent = '';
@@ -257,6 +285,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IDeleteNotificationConfigRequest = {};
       request.name = '';
@@ -280,6 +310,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IDeleteNotificationConfigRequest = {};
       request.name = '';
@@ -308,6 +340,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -331,6 +365,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -356,6 +392,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGetNotificationConfigRequest = {};
       request.name = '';
@@ -379,6 +417,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGetNotificationConfigRequest = {};
       request.name = '';
@@ -404,6 +444,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGetOrganizationSettingsRequest = {};
       request.name = '';
@@ -427,6 +469,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGetOrganizationSettingsRequest = {};
       request.name = '';
@@ -455,6 +499,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGetSourceRequest = {};
       request.name = '';
@@ -478,6 +524,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGetSourceRequest = {};
       request.name = '';
@@ -503,6 +551,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.ISetFindingStateRequest = {};
       request.name = '';
@@ -526,6 +576,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.ISetFindingStateRequest = {};
       request.name = '';
@@ -551,6 +603,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -574,6 +628,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -599,6 +655,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -622,6 +680,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -647,6 +707,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateFindingRequest = {};
       request.finding = {};
@@ -671,6 +733,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateFindingRequest = {};
       request.finding = {};
@@ -697,6 +761,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateNotificationConfigRequest = {};
       request.notificationConfig = {};
@@ -721,6 +787,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateNotificationConfigRequest = {};
       request.notificationConfig = {};
@@ -750,6 +818,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateOrganizationSettingsRequest = {};
       request.organizationSettings = {};
@@ -774,6 +844,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateOrganizationSettingsRequest = {};
       request.organizationSettings = {};
@@ -803,6 +875,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateSourceRequest = {};
       request.source = {};
@@ -827,6 +901,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateSourceRequest = {};
       request.source = {};
@@ -853,6 +929,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateSecurityMarksRequest = {};
       request.securityMarks = {};
@@ -877,6 +955,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IUpdateSecurityMarksRequest = {};
       request.securityMarks = {};
@@ -903,6 +983,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IRunAssetDiscoveryRequest = {};
       request.parent = '';
@@ -933,6 +1015,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IRunAssetDiscoveryRequest = {};
       request.parent = '';
@@ -966,6 +1050,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGroupAssetsRequest = {};
       request.parent = '';
@@ -993,6 +1079,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGroupAssetsRequest = {};
       request.parent = '';
@@ -1025,6 +1113,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGroupFindingsRequest = {};
       request.parent = '';
@@ -1052,6 +1142,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IGroupFindingsRequest = {};
       request.parent = '';
@@ -1084,6 +1176,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IListAssetsRequest = {};
       request.parent = '';
@@ -1111,6 +1205,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IListAssetsRequest = {};
       request.parent = '';
@@ -1143,6 +1239,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IListFindingsRequest = {};
       request.parent = '';
@@ -1170,6 +1268,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IListFindingsRequest = {};
       request.parent = '';
@@ -1202,6 +1302,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IListNotificationConfigsRequest = {};
       request.parent = '';
@@ -1232,6 +1334,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IListNotificationConfigsRequest = {};
       request.parent = '';
@@ -1264,6 +1368,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IListSourcesRequest = {};
       request.parent = '';
@@ -1291,6 +1397,8 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.securitycenter.v1p1beta1.IListSourcesRequest = {};
       request.parent = '';


### PR DESCRIPTION
This PR includes changes from https://github.com/googleapis/gapic-generator-typescript/pull/317
that will move the asynchronous initialization and authentication from the client constructor
to an `initialize()` method. This method will be automatically called when the first RPC call
is performed.

The client library usage has not changed, there is no need to update any code.

If you want to make sure the client is authenticated _before_ the first RPC call, you can do
```js
await client.initialize();
```
manually before calling any client method.