### PR TITLE
feat: check status of long running operation by its name

### DIFF
--- a/src/v1/security_center_client.ts
+++ b/src/v1/security_center_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './security_center_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -2036,6 +2036,42 @@ export class SecurityCenterClient {
     });
     this.initialize();
     return this.innerApiCalls.runAssetDiscovery(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the runAssetDiscovery() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkRunAssetDiscoveryProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkRunAssetDiscoveryProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.securitycenter.v1.RunAssetDiscoveryResponse,
+      protos.google.protobuf.Empty
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.runAssetDiscovery,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.securitycenter.v1.RunAssetDiscoveryResponse,
+      protos.google.protobuf.Empty
+    >;
   }
   groupAssets(
     request: protos.google.cloud.securitycenter.v1.IGroupAssetsRequest,

--- a/src/v1beta1/security_center_client.ts
+++ b/src/v1beta1/security_center_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './security_center_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1616,6 +1616,39 @@ export class SecurityCenterClient {
     });
     this.initialize();
     return this.innerApiCalls.runAssetDiscovery(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the runAssetDiscovery() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkRunAssetDiscoveryProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkRunAssetDiscoveryProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Empty>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.runAssetDiscovery,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Empty
+    >;
   }
   groupAssets(
     request: protos.google.cloud.securitycenter.v1beta1.IGroupAssetsRequest,

--- a/src/v1p1beta1/security_center_client.ts
+++ b/src/v1p1beta1/security_center_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './security_center_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -2075,6 +2075,42 @@ export class SecurityCenterClient {
     });
     this.initialize();
     return this.innerApiCalls.runAssetDiscovery(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the runAssetDiscovery() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkRunAssetDiscoveryProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkRunAssetDiscoveryProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryResponse,
+      protos.google.protobuf.Empty
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.runAssetDiscovery,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryResponse,
+      protos.google.protobuf.Empty
+    >;
   }
   groupAssets(
     request: protos.google.cloud.securitycenter.v1p1beta1.IGroupAssetsRequest,

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-security-center.git",
-        "sha": "8ea195c2f3e83b30045943cd39ccb01a926eb535"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "28e76243c23cc282efbb288cb558c174e3e5e9ee",
-        "internalRef": "308294748"
+        "remote": "git@github.com:googleapis/nodejs-security-center.git",
+        "sha": "073960395fdaafcbdd921fba26ba1ace5e303813"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/test/gapic_security_center_v1.ts
+++ b/test/gapic_security_center_v1.ts
@@ -25,7 +25,7 @@ import * as securitycenterModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -331,9 +331,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createSource(request);
-      }, expectedError);
+      await assert.rejects(client.createSource(request), expectedError);
       assert(
         (client.innerApiCalls.createSource as SinonStub)
           .getCall(0)
@@ -445,9 +443,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createFinding(request);
-      }, expectedError);
+      await assert.rejects(client.createFinding(request), expectedError);
       assert(
         (client.innerApiCalls.createFinding as SinonStub)
           .getCall(0)
@@ -561,9 +557,10 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createNotificationConfig(request);
-      }, expectedError);
+      await assert.rejects(
+        client.createNotificationConfig(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.createNotificationConfig as SinonStub)
           .getCall(0)
@@ -677,9 +674,10 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteNotificationConfig(request);
-      }, expectedError);
+      await assert.rejects(
+        client.deleteNotificationConfig(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.deleteNotificationConfig as SinonStub)
           .getCall(0)
@@ -791,9 +789,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.getIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.getIamPolicy as SinonStub)
           .getCall(0)
@@ -907,9 +903,10 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getNotificationConfig(request);
-      }, expectedError);
+      await assert.rejects(
+        client.getNotificationConfig(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.getNotificationConfig as SinonStub)
           .getCall(0)
@@ -1023,9 +1020,10 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getOrganizationSettings(request);
-      }, expectedError);
+      await assert.rejects(
+        client.getOrganizationSettings(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.getOrganizationSettings as SinonStub)
           .getCall(0)
@@ -1134,9 +1132,7 @@ describe('v1.SecurityCenterClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getSource = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getSource(request);
-      }, expectedError);
+      await assert.rejects(client.getSource(request), expectedError);
       assert(
         (client.innerApiCalls.getSource as SinonStub)
           .getCall(0)
@@ -1248,9 +1244,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setFindingState(request);
-      }, expectedError);
+      await assert.rejects(client.setFindingState(request), expectedError);
       assert(
         (client.innerApiCalls.setFindingState as SinonStub)
           .getCall(0)
@@ -1362,9 +1356,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.setIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.setIamPolicy as SinonStub)
           .getCall(0)
@@ -1478,9 +1470,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.testIamPermissions(request);
-      }, expectedError);
+      await assert.rejects(client.testIamPermissions(request), expectedError);
       assert(
         (client.innerApiCalls.testIamPermissions as SinonStub)
           .getCall(0)
@@ -1595,9 +1585,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateFinding(request);
-      }, expectedError);
+      await assert.rejects(client.updateFinding(request), expectedError);
       assert(
         (client.innerApiCalls.updateFinding as SinonStub)
           .getCall(0)
@@ -1714,9 +1702,10 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateNotificationConfig(request);
-      }, expectedError);
+      await assert.rejects(
+        client.updateNotificationConfig(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.updateNotificationConfig as SinonStub)
           .getCall(0)
@@ -1833,9 +1822,10 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateOrganizationSettings(request);
-      }, expectedError);
+      await assert.rejects(
+        client.updateOrganizationSettings(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.updateOrganizationSettings as SinonStub)
           .getCall(0)
@@ -1950,9 +1940,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateSource(request);
-      }, expectedError);
+      await assert.rejects(client.updateSource(request), expectedError);
       assert(
         (client.innerApiCalls.updateSource as SinonStub)
           .getCall(0)
@@ -2069,9 +2057,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateSecurityMarks(request);
-      }, expectedError);
+      await assert.rejects(client.updateSecurityMarks(request), expectedError);
       assert(
         (client.innerApiCalls.updateSecurityMarks as SinonStub)
           .getCall(0)
@@ -2193,9 +2179,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.runAssetDiscovery(request);
-      }, expectedError);
+      await assert.rejects(client.runAssetDiscovery(request), expectedError);
       assert(
         (client.innerApiCalls.runAssetDiscovery as SinonStub)
           .getCall(0)
@@ -2228,14 +2212,53 @@ describe('v1.SecurityCenterClient', () => {
         expectedError
       );
       const [operation] = await client.runAssetDiscovery(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.runAssetDiscovery as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkRunAssetDiscoveryProgress without error', async () => {
+      const client = new securitycenterModule.v1.SecurityCenterClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkRunAssetDiscoveryProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkRunAssetDiscoveryProgress with error', async () => {
+      const client = new securitycenterModule.v1.SecurityCenterClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkRunAssetDiscoveryProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2358,9 +2381,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.groupAssets(request);
-      }, expectedError);
+      await assert.rejects(client.groupAssets(request), expectedError);
       assert(
         (client.innerApiCalls.groupAssets as SinonStub)
           .getCall(0)
@@ -2456,9 +2477,7 @@ describe('v1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.groupAssets.createStream as SinonStub)
           .getCall(0)
@@ -2674,9 +2693,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.groupFindings(request);
-      }, expectedError);
+      await assert.rejects(client.groupFindings(request), expectedError);
       assert(
         (client.innerApiCalls.groupFindings as SinonStub)
           .getCall(0)
@@ -2773,9 +2790,7 @@ describe('v1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.groupFindings.createStream as SinonStub)
           .getCall(0)
@@ -2994,9 +3009,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listAssets(request);
-      }, expectedError);
+      await assert.rejects(client.listAssets(request), expectedError);
       assert(
         (client.innerApiCalls.listAssets as SinonStub)
           .getCall(0)
@@ -3096,9 +3109,7 @@ describe('v1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listAssets.createStream as SinonStub)
           .getCall(0)
@@ -3316,9 +3327,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listFindings(request);
-      }, expectedError);
+      await assert.rejects(client.listFindings(request), expectedError);
       assert(
         (client.innerApiCalls.listFindings as SinonStub)
           .getCall(0)
@@ -3419,9 +3428,7 @@ describe('v1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listFindings.createStream as SinonStub)
           .getCall(0)
@@ -3642,9 +3649,10 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listNotificationConfigs(request);
-      }, expectedError);
+      await assert.rejects(
+        client.listNotificationConfigs(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.listNotificationConfigs as SinonStub)
           .getCall(0)
@@ -3746,9 +3754,7 @@ describe('v1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listNotificationConfigs
           .createStream as SinonStub)
@@ -3966,9 +3972,7 @@ describe('v1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listSources(request);
-      }, expectedError);
+      await assert.rejects(client.listSources(request), expectedError);
       assert(
         (client.innerApiCalls.listSources as SinonStub)
           .getCall(0)
@@ -4064,9 +4068,7 @@ describe('v1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listSources.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_security_center_v1beta1.ts
+++ b/test/gapic_security_center_v1beta1.ts
@@ -25,7 +25,7 @@ import * as securitycenterModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -331,9 +331,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createSource(request);
-      }, expectedError);
+      await assert.rejects(client.createSource(request), expectedError);
       assert(
         (client.innerApiCalls.createSource as SinonStub)
           .getCall(0)
@@ -445,9 +443,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createFinding(request);
-      }, expectedError);
+      await assert.rejects(client.createFinding(request), expectedError);
       assert(
         (client.innerApiCalls.createFinding as SinonStub)
           .getCall(0)
@@ -559,9 +555,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.getIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.getIamPolicy as SinonStub)
           .getCall(0)
@@ -675,9 +669,10 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getOrganizationSettings(request);
-      }, expectedError);
+      await assert.rejects(
+        client.getOrganizationSettings(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.getOrganizationSettings as SinonStub)
           .getCall(0)
@@ -786,9 +781,7 @@ describe('v1beta1.SecurityCenterClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getSource = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getSource(request);
-      }, expectedError);
+      await assert.rejects(client.getSource(request), expectedError);
       assert(
         (client.innerApiCalls.getSource as SinonStub)
           .getCall(0)
@@ -900,9 +893,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setFindingState(request);
-      }, expectedError);
+      await assert.rejects(client.setFindingState(request), expectedError);
       assert(
         (client.innerApiCalls.setFindingState as SinonStub)
           .getCall(0)
@@ -1014,9 +1005,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.setIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.setIamPolicy as SinonStub)
           .getCall(0)
@@ -1130,9 +1119,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.testIamPermissions(request);
-      }, expectedError);
+      await assert.rejects(client.testIamPermissions(request), expectedError);
       assert(
         (client.innerApiCalls.testIamPermissions as SinonStub)
           .getCall(0)
@@ -1247,9 +1234,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateFinding(request);
-      }, expectedError);
+      await assert.rejects(client.updateFinding(request), expectedError);
       assert(
         (client.innerApiCalls.updateFinding as SinonStub)
           .getCall(0)
@@ -1366,9 +1351,10 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateOrganizationSettings(request);
-      }, expectedError);
+      await assert.rejects(
+        client.updateOrganizationSettings(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.updateOrganizationSettings as SinonStub)
           .getCall(0)
@@ -1483,9 +1469,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateSource(request);
-      }, expectedError);
+      await assert.rejects(client.updateSource(request), expectedError);
       assert(
         (client.innerApiCalls.updateSource as SinonStub)
           .getCall(0)
@@ -1602,9 +1586,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateSecurityMarks(request);
-      }, expectedError);
+      await assert.rejects(client.updateSecurityMarks(request), expectedError);
       assert(
         (client.innerApiCalls.updateSecurityMarks as SinonStub)
           .getCall(0)
@@ -1726,9 +1708,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.runAssetDiscovery(request);
-      }, expectedError);
+      await assert.rejects(client.runAssetDiscovery(request), expectedError);
       assert(
         (client.innerApiCalls.runAssetDiscovery as SinonStub)
           .getCall(0)
@@ -1761,14 +1741,53 @@ describe('v1beta1.SecurityCenterClient', () => {
         expectedError
       );
       const [operation] = await client.runAssetDiscovery(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.runAssetDiscovery as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkRunAssetDiscoveryProgress without error', async () => {
+      const client = new securitycenterModule.v1beta1.SecurityCenterClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkRunAssetDiscoveryProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkRunAssetDiscoveryProgress with error', async () => {
+      const client = new securitycenterModule.v1beta1.SecurityCenterClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkRunAssetDiscoveryProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1893,9 +1912,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.groupAssets(request);
-      }, expectedError);
+      await assert.rejects(client.groupAssets(request), expectedError);
       assert(
         (client.innerApiCalls.groupAssets as SinonStub)
           .getCall(0)
@@ -1995,9 +2012,7 @@ describe('v1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.groupAssets.createStream as SinonStub)
           .getCall(0)
@@ -2215,9 +2230,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.groupFindings(request);
-      }, expectedError);
+      await assert.rejects(client.groupFindings(request), expectedError);
       assert(
         (client.innerApiCalls.groupFindings as SinonStub)
           .getCall(0)
@@ -2318,9 +2331,7 @@ describe('v1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.groupFindings.createStream as SinonStub)
           .getCall(0)
@@ -2539,9 +2550,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listAssets(request);
-      }, expectedError);
+      await assert.rejects(client.listAssets(request), expectedError);
       assert(
         (client.innerApiCalls.listAssets as SinonStub)
           .getCall(0)
@@ -2641,9 +2650,7 @@ describe('v1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listAssets.createStream as SinonStub)
           .getCall(0)
@@ -2861,9 +2868,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listFindings(request);
-      }, expectedError);
+      await assert.rejects(client.listFindings(request), expectedError);
       assert(
         (client.innerApiCalls.listFindings as SinonStub)
           .getCall(0)
@@ -2960,9 +2965,7 @@ describe('v1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listFindings.createStream as SinonStub)
           .getCall(0)
@@ -3179,9 +3182,7 @@ describe('v1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listSources(request);
-      }, expectedError);
+      await assert.rejects(client.listSources(request), expectedError);
       assert(
         (client.innerApiCalls.listSources as SinonStub)
           .getCall(0)
@@ -3277,9 +3278,7 @@ describe('v1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listSources.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_security_center_v1p1beta1.ts
+++ b/test/gapic_security_center_v1p1beta1.ts
@@ -25,7 +25,7 @@ import * as securitycenterModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -331,9 +331,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createSource(request);
-      }, expectedError);
+      await assert.rejects(client.createSource(request), expectedError);
       assert(
         (client.innerApiCalls.createSource as SinonStub)
           .getCall(0)
@@ -445,9 +443,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createFinding(request);
-      }, expectedError);
+      await assert.rejects(client.createFinding(request), expectedError);
       assert(
         (client.innerApiCalls.createFinding as SinonStub)
           .getCall(0)
@@ -561,9 +557,10 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createNotificationConfig(request);
-      }, expectedError);
+      await assert.rejects(
+        client.createNotificationConfig(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.createNotificationConfig as SinonStub)
           .getCall(0)
@@ -677,9 +674,10 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteNotificationConfig(request);
-      }, expectedError);
+      await assert.rejects(
+        client.deleteNotificationConfig(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.deleteNotificationConfig as SinonStub)
           .getCall(0)
@@ -791,9 +789,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.getIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.getIamPolicy as SinonStub)
           .getCall(0)
@@ -907,9 +903,10 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getNotificationConfig(request);
-      }, expectedError);
+      await assert.rejects(
+        client.getNotificationConfig(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.getNotificationConfig as SinonStub)
           .getCall(0)
@@ -1023,9 +1020,10 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getOrganizationSettings(request);
-      }, expectedError);
+      await assert.rejects(
+        client.getOrganizationSettings(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.getOrganizationSettings as SinonStub)
           .getCall(0)
@@ -1134,9 +1132,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getSource = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getSource(request);
-      }, expectedError);
+      await assert.rejects(client.getSource(request), expectedError);
       assert(
         (client.innerApiCalls.getSource as SinonStub)
           .getCall(0)
@@ -1248,9 +1244,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setFindingState(request);
-      }, expectedError);
+      await assert.rejects(client.setFindingState(request), expectedError);
       assert(
         (client.innerApiCalls.setFindingState as SinonStub)
           .getCall(0)
@@ -1362,9 +1356,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.setIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.setIamPolicy as SinonStub)
           .getCall(0)
@@ -1478,9 +1470,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.testIamPermissions(request);
-      }, expectedError);
+      await assert.rejects(client.testIamPermissions(request), expectedError);
       assert(
         (client.innerApiCalls.testIamPermissions as SinonStub)
           .getCall(0)
@@ -1595,9 +1585,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateFinding(request);
-      }, expectedError);
+      await assert.rejects(client.updateFinding(request), expectedError);
       assert(
         (client.innerApiCalls.updateFinding as SinonStub)
           .getCall(0)
@@ -1714,9 +1702,10 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateNotificationConfig(request);
-      }, expectedError);
+      await assert.rejects(
+        client.updateNotificationConfig(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.updateNotificationConfig as SinonStub)
           .getCall(0)
@@ -1833,9 +1822,10 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateOrganizationSettings(request);
-      }, expectedError);
+      await assert.rejects(
+        client.updateOrganizationSettings(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.updateOrganizationSettings as SinonStub)
           .getCall(0)
@@ -1950,9 +1940,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateSource(request);
-      }, expectedError);
+      await assert.rejects(client.updateSource(request), expectedError);
       assert(
         (client.innerApiCalls.updateSource as SinonStub)
           .getCall(0)
@@ -2069,9 +2057,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateSecurityMarks(request);
-      }, expectedError);
+      await assert.rejects(client.updateSecurityMarks(request), expectedError);
       assert(
         (client.innerApiCalls.updateSecurityMarks as SinonStub)
           .getCall(0)
@@ -2193,9 +2179,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.runAssetDiscovery(request);
-      }, expectedError);
+      await assert.rejects(client.runAssetDiscovery(request), expectedError);
       assert(
         (client.innerApiCalls.runAssetDiscovery as SinonStub)
           .getCall(0)
@@ -2228,14 +2212,53 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         expectedError
       );
       const [operation] = await client.runAssetDiscovery(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.runAssetDiscovery as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkRunAssetDiscoveryProgress without error', async () => {
+      const client = new securitycenterModule.v1p1beta1.SecurityCenterClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkRunAssetDiscoveryProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkRunAssetDiscoveryProgress with error', async () => {
+      const client = new securitycenterModule.v1p1beta1.SecurityCenterClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkRunAssetDiscoveryProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2360,9 +2383,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.groupAssets(request);
-      }, expectedError);
+      await assert.rejects(client.groupAssets(request), expectedError);
       assert(
         (client.innerApiCalls.groupAssets as SinonStub)
           .getCall(0)
@@ -2462,9 +2483,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.groupAssets.createStream as SinonStub)
           .getCall(0)
@@ -2682,9 +2701,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.groupFindings(request);
-      }, expectedError);
+      await assert.rejects(client.groupFindings(request), expectedError);
       assert(
         (client.innerApiCalls.groupFindings as SinonStub)
           .getCall(0)
@@ -2785,9 +2802,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.groupFindings.createStream as SinonStub)
           .getCall(0)
@@ -3006,9 +3021,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listAssets(request);
-      }, expectedError);
+      await assert.rejects(client.listAssets(request), expectedError);
       assert(
         (client.innerApiCalls.listAssets as SinonStub)
           .getCall(0)
@@ -3108,9 +3121,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listAssets.createStream as SinonStub)
           .getCall(0)
@@ -3328,9 +3339,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listFindings(request);
-      }, expectedError);
+      await assert.rejects(client.listFindings(request), expectedError);
       assert(
         (client.innerApiCalls.listFindings as SinonStub)
           .getCall(0)
@@ -3431,9 +3440,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listFindings.createStream as SinonStub)
           .getCall(0)
@@ -3654,9 +3661,10 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listNotificationConfigs(request);
-      }, expectedError);
+      await assert.rejects(
+        client.listNotificationConfigs(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.listNotificationConfigs as SinonStub)
           .getCall(0)
@@ -3758,9 +3766,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listNotificationConfigs
           .createStream as SinonStub)
@@ -3980,9 +3986,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listSources(request);
-      }, expectedError);
+      await assert.rejects(client.listSources(request), expectedError);
       assert(
         (client.innerApiCalls.listSources as SinonStub)
           .getCall(0)
@@ -4078,9 +4082,7 @@ describe('v1p1beta1.SecurityCenterClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listSources.createStream as SinonStub)
           .getCall(0)


### PR DESCRIPTION
For each client method returning a long running operation, a separate method to check its status is added.

Added methods: `checkRunAssetDiscoveryProgress`.